### PR TITLE
Initial provisioning for packs and user name changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant
 *.swp
+private_key*

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# TODO Add necessary minimum provisioning
+# TODO Add necessary minimum provisioning for testarteria
 $script = <<EOF
 mkdir -pv /data/testarteria1
 mkdir /data/testarteria1/mon1
@@ -51,7 +51,7 @@ Vagrant.configure(2) do |config|
 
     stackstorm.vm.provision "ansible" do |ansible|
       ansible.playbook = "ansible-st2/playbooks/arteriaexpress.yaml"
-      ansible.sudo = true
+      ansible.inventory_path = "ansible-st2/inventories/test_inventory"
     end
 
   end

--- a/ansible-st2/inventories/test_inventory
+++ b/ansible-st2/inventories/test_inventory
@@ -1,0 +1,3 @@
+[master]
+stackstorm-master
+

--- a/ansible-st2/playbooks/arteriaexpress.yaml
+++ b/ansible-st2/playbooks/arteriaexpress.yaml
@@ -1,6 +1,7 @@
 ---
 - name: Install st2 for arteria
-  hosts: all
+  remote_user: vagrant
+  hosts: master 
   vars:
     # the StackStorm version to install
     version: 0.11.2
@@ -19,4 +20,5 @@
         - st2reactor
     - mysql
     - mistral
-    - st2web 
+    - st2web
+    - arteria 

--- a/ansible-st2/roles/arteria/tasks/main.yml
+++ b/ansible-st2/roles/arteria/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+
+# TODO: Change this user name in a better way in the future.. 
+- name: Change the system user from the default stanley to our provision user
+  sudo: yes
+  replace: regexp="^user = stanley$" replace="user = {{ ansible_ssh_user }}" dest=/etc/st2/st2.conf backup=yes
+
+- name: Change the system user's SSH key
+  sudo: yes
+  replace: regexp="^ssh_key_file = /home/stanley/.ssh/stanley_rsa$" replace="ssh_key_file = /home/{{ ansible_ssh_user }}/.ssh/key" dest=/etc/st2/st2.conf backup=yes
+  notify:
+    - restart st2
+
+- name: Pause for 1 minute until stackstorm services are up and online
+  pause: minutes=1
+
+- name: Get st2 token
+  command: /bin/bash /arteria/arteria-packs/scripts/st2token
+  register: st2token 
+
+- name: Setup virtualenv for arteria-packs
+  command: /bin/bash -c "ST2_AUTH_TOKEN={{ st2token.stdout }} /arteria/arteria-packs/scripts/setup-virtualenv"
+
+- name: Register arteria-packs
+  command: /bin/bash -c "export ST2_AUTH_TOKEN={{ st2token.stdout }} && /arteria/arteria-packs/scripts/register"
+

--- a/ansible-st2/roles/st2packages/tasks/install.yml
+++ b/ansible-st2/roles/st2packages/tasks/install.yml
@@ -8,6 +8,7 @@
     - git
     - python-dev
     - python-setuptools
+    - python-oslo.config
 
 - name: Install pip
   sudo: true

--- a/ansible-st2/roles/st2web/tasks/main.yml
+++ b/ansible-st2/roles/st2web/tasks/main.yml
@@ -4,13 +4,20 @@
   get_url: url=https://downloads.stackstorm.net/releases/st2/{{ version }}/webui/webui-{{ version }}.tar.gz dest=/tmp/
 
 - name: Create /opt/opt/stackstorm/static/
+  sudo: yes
   file: state=directory path=/opt/stackstorm/static/
 
 - name: Uncompress webui
+  sudo: yes
   unarchive: copy=no src=/tmp/webui-{{ version }}.tar.gz  dest=/opt/stackstorm/static/
 
 - name: Set config
+  sudo: yes
   template: src=config.js.j2 dest=/opt/stackstorm/static/webui/config.js 
+
+- name: Change directory owner from default stanley to our local user
+  sudo: yes
+  file: path=/opt/stackstorm/static/webui owner={{ ansible_ssh_user }} group={{ ansible_ssh_user }} recurse=yes 
 
 # TODO This is an ugly fix for now, which we do
 # not want to keep when we move into production.


### PR DESCRIPTION
- Setup a test inventory for ansible so we can run the playbooks manually and from Vagrant.

- Add an initial arteria ansible role that changes the system user from stanley to vagrant and does the setup and registration of the arteria-pack for the master.

- Change ownership of webui files from stanley to vagrant.