### PR TITLE
Supervisor support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant
 *.swp
+private_key*

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,6 +40,7 @@ Vagrant.configure(2) do |config|
     stackstorm.vm.synced_folder "../arteria-packs/", "/opt/stackstorm/packs/arteria-packs"
     stackstorm.vm.synced_folder "../arteria-packs/", "/arteria/arteria-packs"
     stackstorm.vm.synced_folder "../arteria-lib/", "/arteria/arteria-lib"
+    stackstorm.vm.synced_folder "../arteria-provisioning/", "/arteria/arteria-provisioning"
 
     # Forwarding these ports is required for the webui to work
     stackstorm.vm.network :forwarded_port, host: 8080, guest: 8080
@@ -65,6 +66,7 @@ Vagrant.configure(2) do |config|
 
     testtank.vm.synced_folder "../arteria-packs/", "/arteria/arteria-packs"
     testtank.vm.synced_folder "../arteria-lib/", "/arteria/arteria-lib"
+    testtank.vm.synced_folder "../arteria-provisioning/", "/arteria/arteria-provisioning"
 
     testtank.vm.provision "shell", inline: $script
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,11 +20,8 @@ pip install virtualenv
 echo "Installing supervisor"
 apt-get -y install supervisor
 
-echo "Install the arteria core library"
-source_path=/arteria/arteria-lib
-pip install -e file://$source_path/arteria -r $source_path/arteria/requirements/dev
-
 echo "Install services"
+source_path=/arteria/arteria-lib
 product=runfolder
 pushd /arteria/arteria-provisioning/services
 ./install-service $product vagrant vagrant dev $source_path/$product $source_path/arteria /opt/$product 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,10 +12,13 @@ chown -R vagrant:vagrant /srv/samplesheet
 chmod -R g+w /data
 mkdir -pv /data/scratch
 
-echo "Installing basic global python requirements"
+echo "Installing main python requirements (in no virtualenv)"
 apt-get update
 apt-get -y install python-pip
 pip install virtualenv
+
+echo "Installing supervisor"
+apt-get -y install supervisor
 
 echo "Installing the runfolder package"
 cd /arteria/arteria-lib/runfolder/scripts/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,9 +20,15 @@ pip install virtualenv
 echo "Installing supervisor"
 apt-get -y install supervisor
 
-echo "Installing the runfolder package"
-cd /arteria/arteria-lib/runfolder/scripts/
-./install vagrant vagrant
+echo "Install the arteria core library"
+source_path=/arteria/arteria-lib
+pip install -e file://$source_path/arteria -r $source_path/arteria/requirements/dev
+
+echo "Install services"
+product=runfolder
+pushd /arteria/arteria-provisioning/services
+./install-service $product vagrant vagrant dev $source_path/$product $source_path/arteria /opt/$product 
+popd
 
 EOF
 

--- a/dev-dependencies
+++ b/dev-dependencies
@@ -9,3 +9,8 @@ else
     echo "vagrant-hostmanager is already installed"
 fi 
 
+if [ ! -f 'private_key' ]; then
+  echo 'Generating ssh key'
+  ssh-keygen -f private_key -C 'arteria' -P ''
+fi
+

--- a/services/install-service
+++ b/services/install-service
@@ -103,11 +103,12 @@ supervisorconfig_source=/arteria/arteria-provisioning/services/$product.conf
 supervisorconfig_target=/etc/supervisor/conf.d/$product.conf
 
 if [ "$type" == "dev" ]; then
-    echo "Adding symbolic links to the supervisor configs"
-    ln -fs $supervisorconfig_source $supervisorconfig_target
+    additional_args=" --debug"
 else
-    cp -fv $supervisorconfig_source $supervisorconfig_target
+    additional_args=""
 fi
+
+sed "s/{{additional_args}}/$additional_args/" $supervisorconfig_source > $supervisorconfig_target
 
 echo "Update the supervisor configuration"
 supervisorctl update

--- a/services/install-service
+++ b/services/install-service
@@ -6,13 +6,14 @@
 # This requires pip and virtualenv
 
 function usage {
-    echo "install <product> user [group] [type] [source] [installpath]"
+    echo "install-service <product> <user> [group] [type] [src] [arteria-src] [installpath]"
     echo
     echo "  product: The name of the package being installed, e.g. 'runfolder'"
     echo "  user: The user which will run the service"
     echo "  group: The group that should have access to log files etc"
     echo "  type: default 'dev'"
-    echo "  source: default '/arteria/arteria-lib/<product>'"
+    echo "  src: default '/arteria/arteria-lib/<product>'"
+    echo "  arteria-src: default '/arteria/arteria-lib/arteria'"
     echo "  installpath: default '/opt/<product>'"
 }
 
@@ -27,7 +28,8 @@ user=$2
 group=$3
 type=$4
 source=$5
-installpath=$6
+source_arteria=$6
+installpath=$7
 
 if [ "$product" == "" ]; then
     echo "You must supply a product"
@@ -51,6 +53,10 @@ fi
 
 if [ "$source" == "" ]; then
     source="/arteria/arteria-lib/$product"
+fi
+
+if [ "$source_arteria" == "" ]; then
+    source_arteria="/arteria/arteria-lib/arteria"
 fi
 
 if [ "$installpath" == "" ]; then
@@ -80,10 +86,12 @@ source $installpath/bin/activate
 
 if [ "$type" == "dev" ]; then
     echo "Installing the $product package in development mode"
+    pip install -e file://$source_arteria -r $source_arteria/requirements/dev
     pip install -e file://$source -r $source/requirements/dev
 else
     # TODO: Support prod
     echo "NOTE: Installing the $product package in development mode" >&2
+    pip install -e file://$source_arteria -r $source_arteria/requirements/prod
     pip install -e file://$source -r $source/requirements/prod
 fi
 

--- a/services/install-service
+++ b/services/install-service
@@ -73,7 +73,7 @@ virtualenv $installpath/
 cp -v $source/config/app.config $installpath/etc/
 chown -R $user:$group $installpath
 
-logpath=/var/log/$product
+logpath=/var/log/arteria
 echo "Creating log directory at $logpath"
 mkdir -pv $logpath
 chown -R $user:$group $logpath

--- a/services/install-service
+++ b/services/install-service
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+# Sets the environment up for a specific webservice, in particular, copying
+# configuration files, creating log directories etc.
+
+# This requires pip and virtualenv
+
+function usage {
+    echo "install <product> user [group] [type] [source] [installpath]"
+    echo
+    echo "  product: The name of the package being installed, e.g. 'runfolder'"
+    echo "  user: The user which will run the service"
+    echo "  group: The group that should have access to log files etc"
+    echo "  type: default 'dev'"
+    echo "  source: default '/arteria/arteria-lib/<product>'"
+    echo "  installpath: default '/opt/<product>'"
+}
+
+if [ "$(id -u)" != "0" ]; then
+    echo "Running install as '$(id)'"
+    echo "You must run this script as root" 1>&2
+    exit 1
+fi
+
+product=$1
+user=$2
+group=$3
+type=$4
+source=$5
+installpath=$6
+
+if [ "$product" == "" ]; then
+    echo "You must supply a product"
+    usage
+    exit 1
+fi
+
+if [ "$user" == "" ]; then
+    echo "You must supply a user"
+    usage
+    exit 1
+fi
+
+if [ "$group" == "" ]; then
+    group=$user
+fi
+
+if [ "$type" == "" ]; then
+    type="dev"
+fi
+
+if [ "$source" == "" ]; then
+    source="/arteria/arteria-lib/$product"
+fi
+
+if [ "$installpath" == "" ]; then
+    installpath="/opt/$product"
+fi
+
+echo "Stopping all supervisor services in the $product group"
+supervisorctl stop $product:*
+
+echo "Installing from $source to $installpath, type=$type"
+mkdir -pv $installpath/etc
+echo "Creating virtual environment at $installpath"
+virtualenv $installpath/
+cp -v $source/config/app.config $installpath/etc/
+chown -R $user:$group $installpath
+
+logpath=/var/log/$product
+echo "Creating log directory at $logpath"
+mkdir -pv $logpath
+chown -R $user:$group $logpath
+echo "Copying default logger.config to $installpath/etc"
+cp $source/config/logger.config $installpath/etc/
+
+# activate the virtualenv
+echo "Switching to the '$installpath' virtualenv"
+source $installpath/bin/activate
+
+if [ "$type" == "dev" ]; then
+    echo "Installing the $product package in development mode"
+    pip install -e file://$source -r $source/requirements/dev
+else
+    # TODO: Support prod
+    echo "NOTE: Installing the $product package in development mode" >&2
+    pip install -e file://$source -r $source/requirements/prod
+fi
+
+echo "Deactivating the python virtual environment"
+deactivate
+
+echo "Registering the service under supervisor control"
+supervisorconfig_source=/arteria/arteria-provisioning/services/$product.conf
+supervisorconfig_target=/etc/supervisor/conf.d/$product.conf
+
+if [ "$type" == "dev" ]; then
+    echo "Adding symbolic links to the supervisor configs"
+    ln -fs $supervisorconfig_source $supervisorconfig_target
+else
+    cp -fv $supervisorconfig_source $supervisorconfig_target
+fi
+
+echo "Update the supervisor configuration"
+supervisorctl update
+
+echo "Start all services in the $product group"
+supervisorctl start $product:*
+supervisorctl status
+
+if [ "$type" == "dev" ]; then
+    echo "Add $product-ws-test for easy integration testing"
+    testbin="/usr/bin/$product-ws-test"
+    echo "source $installpath/bin/activate" > $testbin
+    echo "nosetests $source/tests/integration" >> $testbin
+    chmod +x $testbin
+    echo "Running integration tests..."
+    # TODO: Query for started rather than sleeping
+    sleep 2
+    $testbin
+else
+    echo "Not running tests"
+fi

--- a/services/runfolder.conf
+++ b/services/runfolder.conf
@@ -1,0 +1,7 @@
+[program:runfolder]
+process_name = runfolder-%(process_num)s
+command = /opt/runfolder/bin/runfolder-ws
+              --port %(process_num)s
+# Set numprocs to 2 to run 2 processes, on ports [10800, 10801]
+numprocs = 1
+numprocs_start=10800

--- a/services/runfolder.conf
+++ b/services/runfolder.conf
@@ -1,7 +1,7 @@
 [program:runfolder]
 process_name = runfolder-%(process_num)s
 command = /opt/runfolder/bin/runfolder-ws
-              --port %(process_num)s
+              --port %(process_num)s{{additional_args}}
 # Set numprocs to 2 to run 2 processes, on ports [10800, 10801]
 numprocs = 1
 numprocs_start=10800


### PR DESCRIPTION
Vagrantfile provisioning:
  - installs supervisor as a daemon
  - calls the generic install-service script for the runfolder

Install-service:
  - Creates a virtual environment at /opt/product_name
  - Installs the arteria core library
  - Installs the webservice project
  - Sets the service up in supervisor (a file called product_name.conf is needed in the same directory as install-service)
  - Starts the service
  - Runs tests

Unrelated:
 * Added private_key generation in dev-dependencies, for convenience