### PR TITLE
Updated the runfolder.conf, providing product

### DIFF
--- a/services/runfolder.conf
+++ b/services/runfolder.conf
@@ -1,6 +1,7 @@
 [program:runfolder]
 process_name = runfolder-%(process_num)s
 command = /opt/runfolder/bin/runfolder-ws
+              --product runfolder
               --port %(process_num)s{{additional_args}}
 # Set numprocs to 2 to run 2 processes, on ports [10800, 10801]
 numprocs = 1


### PR DESCRIPTION
This is a minor bug. It was possible to leave out the product, where it defaulted to __package__. I've removed support for that after moving argument parsing to core.